### PR TITLE
updated engine versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/shobhitmshr002/node-messageq"
   },
   "engines": {
-    "node": "8.1.x",
-    "npm": "5.6.x"
+    "node": ">=8.1.0 <=12.22.1",
+    "npm": ">=5.6.0 <=6.13.7"
   },
   "dependencies": {
     "amqplib": "^0.5.2",


### PR DESCRIPTION
To solve this
```
npm WARN notsup Unsupported engine for node-messageq@0.1.0: wanted: {"node":"8.1.x","npm":"5.6.x"} (current: {"node":"12.14.1","npm":"6.13.4"})
npm WARN notsup Not compatible with your version of node/npm: node-messageq@0.1.0
```